### PR TITLE
fix: ScrollViewer style перенесен в fileTabItem

### DIFF
--- a/src/Noty/Resources/Styles/DarkGrayTheme.xaml
+++ b/src/Noty/Resources/Styles/DarkGrayTheme.xaml
@@ -936,76 +936,7 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-
-    <Style x:Key="ScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                    <Grid x:Name="Grid" Background="{DynamicResource BodyTextAreaBackground}">
-
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20*"/>
-                            <ColumnDefinition Width="100*"/>
-                            <ColumnDefinition Width="20*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="100*"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-
-                        <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanHorizontallyScroll="False" ContentTemplate="{TemplateBinding ContentTemplate}" CanVerticallyScroll="False" Grid.ColumnSpan="3" Grid.Row="0" Content="{TemplateBinding Content}" CanContentScroll="{TemplateBinding CanContentScroll}"/>
-
-                        <ScrollBar Style="{DynamicResource ScrollBarStyle}" x:Name="PART_VerticalScrollBar" 
-                                       AutomationProperties.AutomationId="VerticalScrollBar" 
-                                       Cursor="Arrow" Grid.Column="3" 
-                                       Maximum="{TemplateBinding ScrollableHeight}" 
-                                       Minimum="0" Grid.Row="0" 
-                                       Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" 
-                                       ViewportSize="{TemplateBinding ViewportHeight}" 
-                                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"/>
-
-                        <ScrollBar Style="{DynamicResource ScrollBarStyle}" x:Name="PART_HorizontalScrollBar" 
-                                       AutomationProperties.AutomationId="HorizontalScrollBar" 
-                                       Cursor="Arrow" 
-                                       Maximum="{TemplateBinding ScrollableWidth}" 
-                                       Minimum="0" 
-                                       Orientation="Horizontal" 
-                                       Grid.Row="1" 
-                                       Grid.Column="1" 
-                                       Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" 
-                                       ViewportSize="{TemplateBinding ViewportWidth}" 
-                                       Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"/>
-
-                        <Border Grid.Column="0" Grid.ColumnSpan="1" Grid.Row="1" Style="{DynamicResource SubBorderNoBorder}" Margin="0,0,-1,0">
-                            <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                <TextBlock Text="Method: " Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}" />
-                                <TextBlock Name="method_name" Text="{Binding CurrentMethod, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}" />
-                            </StackPanel>
-                        </Border>
-
-                        <Border Grid.Column="2" Grid.ColumnSpan="2" Grid.Row="1" Style="{DynamicResource SubBorderNoBorder}" Margin="-1,0,0,0">
-                            <StackPanel Grid.Column="2" Orientation="Horizontal" TextOptions.TextFormattingMode="Ideal" TextOptions.TextRenderingMode="Auto">
-                                <TextBlock Text="Ln:" Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{DynamicResource HeaderFooterText}"/>
-                                <TextBlock Text="{Binding CurrentLnNumber, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, ElementName=FileTabControl}" VerticalAlignment="Center" FontSize="12" Margin="0,0,5,0"  Foreground="{StaticResource HeaderFooterText}"/>
-                                <TextBlock Text="Ch:" Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{DynamicResource HeaderFooterText}"/>
-                                <TextBlock Text="{Binding CurrentChNumber, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, ElementName=FileTabControl}" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}"/>
-                            </StackPanel>
-                        </Border>
-
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-
-        <Style.Triggers>
-            <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-            </Trigger>
-        </Style.Triggers>
-    </Style>
-
+    
     <!--#endregion-->
     
 </ResourceDictionary>

--- a/src/Noty/Views/Controls/FileTabItem.xaml
+++ b/src/Noty/Views/Controls/FileTabItem.xaml
@@ -5,7 +5,83 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Noty" 
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800" x:Name="fileTabControl">
+             d:DesignHeight="450" d:DesignWidth="800" x:Name="FileTabControl">
+    <UserControl.Resources>
+        
+        <!--ScrollViewerStyle-->
+        <Style x:Key="ScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                        <Grid x:Name="Grid" Background="{DynamicResource BodyTextAreaBackground}">
+
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="20*"/>
+                                <ColumnDefinition Width="100*"/>
+                                <ColumnDefinition Width="20*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="100*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanHorizontallyScroll="False" ContentTemplate="{TemplateBinding ContentTemplate}" CanVerticallyScroll="False" Grid.ColumnSpan="3" Grid.Row="0" Content="{TemplateBinding Content}" CanContentScroll="{TemplateBinding CanContentScroll}"/>
+
+                            <ScrollBar Style="{DynamicResource ScrollBarStyle}" x:Name="PART_VerticalScrollBar" 
+                                       AutomationProperties.AutomationId="VerticalScrollBar" 
+                                       Cursor="Arrow" Grid.Column="3" 
+                                       Maximum="{TemplateBinding ScrollableHeight}" 
+                                       Minimum="0" Grid.Row="0" 
+                                       Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" 
+                                       ViewportSize="{TemplateBinding ViewportHeight}" 
+                                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"/>
+
+                            <ScrollBar Style="{DynamicResource ScrollBarStyle}" x:Name="PART_HorizontalScrollBar" 
+                                       AutomationProperties.AutomationId="HorizontalScrollBar" 
+                                       Cursor="Arrow" 
+                                       Maximum="{TemplateBinding ScrollableWidth}" 
+                                       Minimum="0" 
+                                       Orientation="Horizontal" 
+                                       Grid.Row="1" 
+                                       Grid.Column="1" 
+                                       Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" 
+                                       ViewportSize="{TemplateBinding ViewportWidth}" 
+                                       Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"/>
+                            
+                            <!--left side-->
+                            <Border Grid.Column="0" Grid.ColumnSpan="1" Grid.Row="1" Style="{DynamicResource SubBorderNoBorder}" Margin="0,0,-1,0">
+                                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                                    <TextBlock Text="Method: " Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}" />
+                                    <TextBlock Name="method_name" Text="{Binding CurrentMethod, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}" />
+                                </StackPanel>
+                            </Border>
+                            
+                            <!--right side-->
+                            <Border Grid.Column="2" Grid.ColumnSpan="2" Grid.Row="1" Style="{DynamicResource SubBorderNoBorder}" Margin="-1,0,0,0">
+                                <StackPanel Grid.Column="2" Orientation="Horizontal" TextOptions.TextFormattingMode="Ideal" TextOptions.TextRenderingMode="Auto">
+                                    <TextBlock Text="Ln:" Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{DynamicResource HeaderFooterText}"/>
+                                    <TextBlock Text="{Binding CurrentLnNumber, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, ElementName=FileTabControl}" VerticalAlignment="Center" FontSize="12" Margin="0,0,5,0"  Foreground="{StaticResource HeaderFooterText}"/>
+                                    <TextBlock Text="Ch:" Margin="2,0,2,0" VerticalAlignment="Center" FontSize="12" Foreground="{DynamicResource HeaderFooterText}"/>
+                                    <TextBlock Text="{Binding CurrentChNumber, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, ElementName=FileTabControl}" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource HeaderFooterText}"/>
+                                </StackPanel>
+                            </Border>
+
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+
+            <Style.Triggers>
+                <Trigger Property="IsEnabled" Value="false">
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+    </UserControl.Resources>
+    
     <Grid>
         <!--Content middle side-->
         <ScrollViewer Style="{DynamicResource ScrollViewerStyle}"
@@ -13,8 +89,6 @@
                       VerticalScrollBarVisibility="Visible">
             
             <TextBox Name="TextArea" 
-                     Grid.Row="0"
-                     Grid.ColumnSpan="3"
                      BorderThickness="0" 
                      BorderBrush="{DynamicResource Transparent}"
                      Background="{DynamicResource Transparent}"
@@ -31,7 +105,9 @@
                      FontSize="{Binding FontSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                      Text="{Binding TextContent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" >
             </TextBox>
-            
+
         </ScrollViewer>
+        
     </Grid>
+    
 </UserControl>


### PR DESCRIPTION
### Проблема

* Запутанная логика привязки полей к code-behind filetabitem (view) из переопределенного style для элемента ScrollViewer

### Решение

* Блок xaml кода перенесен непосредственно в ресурсы filetabitem